### PR TITLE
Export the "fingerprinting surface" definition.

### DIFF
--- a/index.html
+++ b/index.html
@@ -258,8 +258,8 @@
       <h2 id="identifying">Identifying fingerprinting surface and evaluating severity</h2>
       
       <p class="issue">Re: <a href="https://github.com/w3c/fingerprinting-guidance/issues/13">Issue 13: actionability through a decision tree or other</a>, this section is intended to provide advice on identifying fingerprinting surface and evaluating severity based on several factors.</p>
-      
-      <p>To mitigate browser fingerprinting in your specification, first identify what features could be used for browser fingerprinting. The <dfn>fingerprinting surface</dfn> of a user agent is the set of observable characteristics that can be used in concert to identify a user, user agent or device or correlate its activity.</p>
+
+      <p>To mitigate browser fingerprinting in your specification, first identify what features could be used for browser fingerprinting. The <dfn id="dfn-fingerprinting-surface" data-export="">fingerprinting surface</dfn> of a user agent is the set of observable characteristics that can be used in concert to identify a user, user agent or device or correlate its activity.</p>
 
       <p>Data sources that may be used for browser fingerprinting include:</p>
       <ul>

--- a/index.html
+++ b/index.html
@@ -165,7 +165,7 @@
       <h2>Browser fingerprinting</h2>
         <section>
         <h2>What is fingerprinting?</h2>
-        <p>In short, <dfn>browser fingerprinting</dfn> is the capability of a site to identify or re-identify a visiting user, user agent or device via configuration settings or other observable characteristics.</p>
+        <p>In short, <dfn id="dfn-browser-fingerprinting" data-export="">browser fingerprinting</dfn> is the capability of a site to identify or re-identify a visiting user, user agent or device via configuration settings or other observable characteristics.</p>
         <p>A similar definition is provided by [[RFC6973]]. A more detailed list of types of fingerprinting is included below. This document does not attempt to catalog all features currently used or usable for browser fingerprinting; however, <a href="#research"></a> provides links to browser vendor pages and academic findings.</p>
         </section>
         <section>


### PR DESCRIPTION
If this isn't the term you want other specs to link to, you should `id="..." data-export=""` whatever terms we _should_ use.
