### PR TITLE
Set up auto-publish

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   main:
     name: Build, Validate and Deploy
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: w3c/spec-prod@v2

--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -1,0 +1,19 @@
+# .github/workflows/pr-push.yml
+name: CI
+on:
+  pull_request: {}
+  push:
+    branches: [gh-pages]
+jobs:
+  main:
+    name: Build, Validate and Deploy
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: w3c/spec-prod@v2
+        with:
+          W3C_ECHIDNA_TOKEN: ${{ secrets.W3C_TR_TOKEN }}
+          W3C_WG_DECISION_URL: [replace with actual link to decision]
+          W3C_BUILD_OVERRIDE: |
+             shortName: fingerprinting-guidance
+             specStatus: IG-NOTE

--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -16,4 +16,4 @@ jobs:
           W3C_WG_DECISION_URL: [replace with actual link to decision]
           W3C_BUILD_OVERRIDE: |
              shortName: fingerprinting-guidance
-             specStatus: IG-NOTE
+             specStatus: NOTE

--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -9,7 +9,7 @@ jobs:
     name: Build, Validate and Deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: w3c/spec-prod@v2
         with:
           W3C_ECHIDNA_TOKEN: ${{ secrets.W3C_TR_TOKEN }}

--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -15,5 +15,4 @@ jobs:
           W3C_ECHIDNA_TOKEN: ${{ secrets.W3C_TR_TOKEN }}
           W3C_WG_DECISION_URL: [replace with actual link to decision]
           W3C_BUILD_OVERRIDE: |
-             shortName: fingerprinting-guidance
              specStatus: NOTE


### PR DESCRIPTION
This still needs the proper link to the Group decision to publish but otherwise it should work.

Note that the secret has been encoded at
 https://github.com/w3c/fingerprinting-guidance/settings/secrets/actions