### PR TITLE
Editorial: add Oxford comma to fingerprinting definition

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,7 +132,7 @@
       <h2>Browser fingerprinting</h2>
         <section>
         <h2>What is fingerprinting?</h2>
-        <p>In short, <dfn id="dfn-browser-fingerprinting" data-export="">browser fingerprinting</dfn> is the capability of a site to identify or re-identify a visiting user, user agent or device via configuration settings or other observable characteristics.</p>
+        <p>In short, <dfn id="dfn-browser-fingerprinting" data-export="">browser fingerprinting</dfn> is the capability of a site to identify or re-identify a visiting user, user agent, or device via configuration settings or other observable characteristics.</p>
         <p>A similar definition is provided by [[?RFC6973]]. A more detailed list of types of fingerprinting is included below. This document does not attempt to catalog all features currently used or usable for browser fingerprinting; however, <a href="#research"></a> provides links to browser vendor pages and academic findings.</p>
         </section>
         <section id="privacy_threat_models">


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/fingerprinting-guidance/pull/83.html" title="Last updated on Jul 1, 2025, 12:32 PM UTC (72dba25)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/fingerprinting-guidance/83/f7c5f77...72dba25.html" title="Last updated on Jul 1, 2025, 12:32 PM UTC (72dba25)">Diff</a>